### PR TITLE
Fix site instability by removing problematic execute configuration

### DIFF
--- a/jupyterbook/myst.yml
+++ b/jupyterbook/myst.yml
@@ -7,9 +7,6 @@ project:
   github: PolicyEngine/crfb-tob-impacts
   bibliography:
     - references.bib
-  execute:
-    execute_notebooks: cache
-    timeout: 600
   toc:
     - file: intro.md
     - file: policy-options.md


### PR DESCRIPTION
## Problem
The site formatting was breaking across all pages due to incorrect myst.yml configuration.

## Root Cause
The `execute` configuration added under `project` section was causing MyST build issues. MyST handles notebook execution automatically during the build process, and the explicit configuration was creating conflicts.

## Solution
Remove the problematic execute configuration from myst.yml. MyST will handle notebook execution properly without explicit configuration.

## Testing
- CI will validate the build works correctly
- Site should render all pages properly after deployment

This is an urgent fix to restore site stability.