### PR TITLE
Add Claude Code plugin configuration for analysis tools

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "plugins": {
+    "marketplaces": [
+      "PolicyEngine/policyengine-claude"
+    ],
+    "auto_install": [
+      "analysis-tools@policyengine-claude"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds **policyengine-claude plugin configuration** to enable automated installation of skills for PolicyEngine analysis workflows.

## Changes

- ✅ Add plugin auto-install configuration in `.claude/settings.json`
- ✅ Configure auto-install of `analysis-tools` plugin from `PolicyEngine/policyengine-claude`

## What's Included

The `analysis-tools` plugin provides **3 skills** (reference documentation):

### 1. policyengine-us-skill
- Situation creation patterns (single, married, families)  
- Common variables reference (income, deductions, benefits, taxes)
- Using axes for parameter sweeps
- Policy reform definitions
- Helper functions and examples

### 2. policyengine-analysis-skill  
- Impact analysis patterns (distributional, case studies)
- Plotly visualizations with PolicyEngine branding (teal #39C6C0)
- Streamlit dashboard templates
- Jupyter notebook best practices
- Reform analysis code templates

### 3. policyengine-standards-skill
- Python standards (Black, 79-char, `uv run`)
- React standards (Prettier + ESLint)
- Changelog management (`changelog_entry.yaml`)
- Git workflow best practices
- Common AI pitfalls

## Benefits

### For Analysis Work
- ✅ **Reference documentation** - Claude automatically knows PolicyEngine patterns
- ✅ **Best practices** - Consistent code quality and visualization standards
- ✅ **Faster development** - Templates and examples for common analysis tasks
- ✅ **Team standardization** - Everyone uses the same patterns

### How It Works
Skills are **automatically loaded** by Claude when relevant. For example:

```
You: "Create a Streamlit dashboard analyzing CTC reform impacts"

Claude: [Uses policyengine-analysis-skill for dashboard patterns]
        [Uses policyengine-us-skill for simulation setup]
        [Uses policyengine-standards-skill for code quality]
```

## Installation

### Automatic (Recommended)
When you trust this repo in Claude Code, the plugin auto-installs!

### Manual (Optional)
```bash
/plugin marketplace add PolicyEngine/policyengine-claude
/plugin install analysis-tools@policyengine-claude
```

## Testing

After merging:
1. Team members trust the repo in Claude Code
2. Plugin auto-installs from marketplace
3. Skills are automatically available when working on analysis
4. Try asking Claude to create analysis code and observe it using the skill patterns

## Related

- Plugin Repository: https://github.com/PolicyEngine/policyengine-claude
- Country model PRs: PolicyEngine/policyengine-us#6692, PolicyEngine/policyengine-uk#1362

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>