### PR TITLE
Add saved-H5 rescoring and long-run findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,36 +14,19 @@ uv pip install -e .
 python scripts/generate_policy_impacts.py
 
 # Build Jupyter Book documentation
-cd jupyterbook && myst build --html
+cd jupyterbook && jupyter-book build .
 
-# Run Next dashboard
-cd dashboard && npm ci && npm run dev
+# Run React dashboard
+cd policy-impact-dashboard && npm install && npm start
 ```
 
 ## Project Structure
 
 - `src/` - Core Python modules (reforms, calculations)
 - `jupyterbook/` - Jupyter Book documentation
-- `dashboard/` - Next.js visualization dashboard
+- `policy-impact-dashboard/` - React visualization dashboard
 - `data/` - Generated CSV data files
 - `tests/` - Test suite
-
-## Deployment
-
-The production site is deployed on Vercel as a combined static build:
-
-- documentation at `/`
-- dashboard at `/dashboard`
-
-Local production-style build:
-
-```bash
-python3 -m pip install -e .
-npm --prefix dashboard ci
-./scripts/build_vercel_site.sh
-```
-
-That writes the combined output to `.vercel-site/`.
 
 ## Data Generation
 
@@ -52,3 +35,39 @@ The project uses PolicyEngine to simulate fiscal and household impacts:
 - **scripts/generate_policy_impacts.py** - Data generation using PolicyEngine simulations
 - Output saved to `data/` and dashboard `public/` directories
 - **PolicyEngine-US Version**: 1.398.0
+
+## Saved-H5 Rescoring
+
+For long-run checks, this repo can rescore reforms against prebuilt H5 datasets
+instead of the legacy baseline-override CSV workflow.
+
+Use [scripts/score_saved_h5_reforms.py](/Users/maxghenis/PolicyEngine/crfb-tob-impacts/scripts/score_saved_h5_reforms.py):
+
+```bash
+export CRFB_TAX_ASSUMPTION_MODULE=/absolute/path/to/policyengine-us-data/policyengine_us_data/datasets/cps/long_term/tax_assumptions.py
+
+PYTHONPATH=/absolute/path/to/policyengine-us \
+uv run python scripts/score_saved_h5_reforms.py \
+  --dataset oact2100=/absolute/path/to/2100.h5 \
+  --reform option1 \
+  --reform option8 \
+  --reform option11 \
+  --tax-assumption-module "$CRFB_TAX_ASSUMPTION_MODULE" \
+  --compare-csv results/oact_static_current.csv \
+  --compare-units billions \
+  --output results/local_oact_saved_h5_checks.csv
+```
+
+Notes:
+- The current long-run checks depend on the local `policyengine-us` wage-base fix from PR `#7912`.
+- The scorer validates saved-H5 metadata against the expected calibration profile, target source, and tax-assumption name before running.
+- The scorer forces saved-H5 metadata validation even if `CRFB_ALLOW_UNVALIDATED_DATASETS=1` is set in the shell.
+- The scorer also rejects filename/metadata year mismatches, so mislabeled H5 files do not get scored for the wrong period.
+- If `--tax-assumption-module` is omitted, the scorer tries common local checkout paths or `CRFB_TAX_ASSUMPTION_MODULE`.
+- Legacy CRFB results CSVs are in billions, while saved-H5 rescoring outputs are in dollars.
+- `results/oact_static_current.csv` is treated as a frozen legacy comparison artifact. The post-OBBBA baseline scripts do not overwrite it.
+- Baseline summaries are cached under `.cache/saved_h5_baselines/` so repeated checks on the same year can skip the initial baseline pass.
+- A tracked summary of the representative deltas lives in [analysis/saved_h5_representative_checks.md](/Users/maxghenis/PolicyEngine/crfb-tob-impacts/analysis/saved_h5_representative_checks.md).
+- The backing three-year local artifacts used for those tables are `results/local_oact_saved_h5_3year_checks.csv` and `results/local_oact_saved_h5_3year_checks_billions.csv`. Those are local runtime outputs, not tracked repo artifacts.
+- Completed `2090`/`2100` all-reforms summaries live in [analysis/saved_h5_all_reforms_2090_2100.md](/Users/maxghenis/PolicyEngine/crfb-tob-impacts/analysis/saved_h5_all_reforms_2090_2100.md).
+- A broader tracked findings note lives in [analysis/long_run_rescoring_findings.md](/Users/maxghenis/PolicyEngine/crfb-tob-impacts/analysis/long_run_rescoring_findings.md).

--- a/analysis/long_run_rescoring_findings.md
+++ b/analysis/long_run_rescoring_findings.md
@@ -1,0 +1,104 @@
+# Long-Run Rescoring Findings
+
+This note summarizes what we have established so far from rescoring reforms on
+corrected long-run saved H5 datasets instead of relying on the legacy
+baseline-override CSV workflow.
+
+## Setup
+
+Current corrected long-run checks use:
+
+- calibrated saved H5 datasets from the `us-data-calibration-contract` worktree
+- target source `oact_2025_08_05_provisional`
+- baseline tax assumption `trustees-core-thresholds-v1`
+- the local `policyengine-us` wage-base fix from PR `#7912`
+
+Representative saved H5 inputs used so far:
+
+- `2075.h5`
+- `2090.h5`
+- `2100.h5`
+
+## Main Findings
+
+1. `results/oact_static_current.csv` is stale for long-run reform scoring.
+
+   It is not equivalent to rescoring reforms on corrected long-run microdata.
+   The corrected saved-H5 path changes actual reform impacts, not just baseline
+   TOB columns.
+
+2. The corrected long-run baseline changes reform scores materially.
+
+   Three-year spot checks on `option1`, `option8`, and `option11` show that the
+   deltas versus the old CRFB file are often large enough to matter for any
+   external reporting.
+
+3. The sign of the change is not uniform across reforms.
+
+   Repeal (`option1`) becomes less negative once corrected baseline TOB is
+   lower, but non-repeal reforms can move either up or down depending on year
+   and trust-fund component.
+
+4. The saved-H5 rescoring workflow is operationally usable now.
+
+   It is still expensive on first load for a new long-run year, but baseline
+   caching makes repeated checks on the same year practical.
+
+5. Full far-tail all-reforms runs are now complete for `2090` and `2100`.
+
+   Those results are tracked separately in
+   `analysis/saved_h5_all_reforms_2090_2100.md`.
+
+6. Not every long-run duplicate row should be read as true policy convergence.
+
+   - `option5`, `option6`, and `option12` do appear to converge to the same
+     long-run policy state.
+   - But the current `policyengine-us` dependency also introduces two
+     implementation caveats:
+     - the Social Security credit path appears to stop affecting liability
+       after `2035`, which affects the interpretation of `option4` and
+       `option11`
+     - the active senior-deduction extension stops at `2099-12-31`, so `2100`
+       `option3` results are not a clean permanent-policy endpoint
+
+## Representative Deltas
+
+All values below are in billions of dollars.
+
+| Reform | Year | New Revenue | Old Revenue | Delta | OASDI TOB Delta | HI TOB Delta |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `option1` | 2075 | -1476.389 | -1500.710 | 24.321 | 12.790 | 11.532 |
+| `option8` | 2075 | 413.597 | 510.380 | -96.783 | -16.263 | -80.529 |
+| `option11` | 2075 | 79.129 | 105.036 | -25.906 | 1.933 | -27.839 |
+| `option1` | 2090 | -2634.736 | -2646.220 | 11.484 | 3.974 | 7.510 |
+| `option8` | 2090 | 922.182 | 859.300 | 62.882 | -31.711 | 94.594 |
+| `option11` | 2090 | 297.056 | 181.358 | 115.698 | -18.457 | 134.155 |
+| `option1` | 2100 | -3841.095 | -3852.810 | 11.715 | 7.356 | 4.359 |
+| `option8` | 2100 | 855.222 | 1318.330 | -463.108 | -44.394 | -418.714 |
+| `option11` | 2100 | 49.579 | 321.851 | -272.272 | -33.532 | -238.740 |
+
+## Runtime Notes
+
+- First baseline load for a new long-run year is expensive, roughly four
+  minutes in the current environment.
+- Once cached, later rescoring on the same saved H5 skips that baseline pass.
+- Per-reform scoring is still expensive enough that full-year all-reforms runs
+  should be treated as batch jobs, not interactive checks.
+
+## Recommended Year Grid For Fast Delivery
+
+If the goal is to produce an updated set of CRFB numbers quickly, the most
+defensible coarse year grid is:
+
+- every year `2026-2035`
+- plus `2036`, `2037`, `2038`, `2045`, `2049`, `2062`, `2063`
+- plus `2070`, `2080`, `2090`, `2100`
+
+This grid is based on actual reform discontinuities in `src/reforms.py`, not
+just arbitrary decade spacing.
+
+## Current Caveat
+
+These rescoring results still depend on the local `policyengine-us` wage-base
+fix from PR `#7912`, which is not merged yet. Until that fix lands, the
+workflow is reproducible from branch state, not from released package state.

--- a/analysis/saved_h5_all_reforms_2090_2100.md
+++ b/analysis/saved_h5_all_reforms_2090_2100.md
@@ -1,0 +1,81 @@
+# Saved-H5 All-Reforms Checks For 2090 And 2100
+
+These tables summarize the completed all-reforms rescoring runs on corrected
+long-run saved H5 datasets for `2090` and `2100`.
+
+Setup:
+
+- target source: `oact_2025_08_05_provisional`
+- baseline tax assumption: `trustees-core-thresholds-v1`
+- scoring path: `scripts/score_saved_h5_reforms.py`
+- comparison file: `results/oact_static_current.csv`
+- current dependency: local `policyengine-us` wage-base fix from PR `#7912`
+
+All values below are in billions of dollars.
+
+## 2090
+
+| Reform | Revenue New | Revenue Old | Revenue Delta | OASDI TOB Delta | HI TOB Delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `option1` | -2634.736 | -2646.220 | 11.484 | 3.974 | 7.510 |
+| `option2` | 297.056 | 205.390 | 91.666 | -31.711 | 123.367 |
+| `option3` | 296.578 | 191.990 | 104.588 | -32.697 | 127.299 |
+| `option4` | 297.056 | 121.805 | 175.251 | 34.372 | 140.878 |
+| `option5` | -607.642 | 429.440 | -1037.082 | 3.974 | 7.510 |
+| `option6` | -607.642 | 429.440 | -1037.082 | 3.974 | 7.510 |
+| `option7` | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |
+| `option8` | 922.182 | 859.300 | 62.882 | -31.711 | 94.594 |
+| `option9` | 521.135 | 420.638 | 100.497 | -31.707 | 132.204 |
+| `option10` | 725.488 | 639.136 | 86.352 | -31.707 | 118.059 |
+| `option11` | 297.056 | 181.358 | 115.698 | -18.457 | 134.155 |
+| `option12` | -607.642 | 429.440 | -1037.082 | 3.974 | 7.510 |
+
+## 2100
+
+| Reform | Revenue New | Revenue Old | Revenue Delta | OASDI TOB Delta | HI TOB Delta |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `option1` | -3841.095 | -3852.810 | 11.715 | 7.356 | 4.359 |
+| `option2` | 49.579 | 340.350 | -290.771 | -44.394 | -246.377 |
+| `option3` | 49.579 | 340.350 | -290.771 | -44.394 | -246.377 |
+| `option4` | 49.579 | 245.619 | -196.040 | 33.303 | -229.343 |
+| `option5` | -835.344 | 865.640 | -1700.984 | 7.356 | 4.359 |
+| `option6` | -835.344 | 865.640 | -1700.984 | 7.356 | 4.359 |
+| `option7` | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |
+| `option8` | 855.222 | 1318.330 | -463.108 | -44.394 | -418.714 |
+| `option9` | 316.792 | 663.480 | -346.687 | -44.396 | -302.291 |
+| `option10` | 585.824 | 990.900 | -405.076 | -44.396 | -360.679 |
+| `option11` | 49.579 | 321.851 | -272.272 | -33.532 | -238.740 |
+| `option12` | -835.344 | 865.640 | -1700.984 | 7.356 | 4.359 |
+
+## High-Level Read
+
+- The corrected long-run baseline materially changes almost every non-zero
+  reform effect at both `2090` and `2100`.
+- The direction is not uniform across reforms.
+  - `option1` becomes modestly less negative in both years.
+  - several positive-revenue options shrink sharply by `2100`.
+  - some `2090` non-repeal options become larger than the old file implied.
+- Several reforms collapse to identical results in the corrected path, but
+  those matches do not all mean the same thing.
+  - `option5`, `option6`, and `option12` match exactly in both `2090` and
+    `2100`, which is consistent with those policies reaching the same long-run
+    end state.
+  - `option2`, `option4`, and `option11` clustering by `2090` and `2100`
+    should not yet be interpreted as clean economic convergence. Under the
+    current `policyengine-us` dependency, the Social Security credit path
+    appears to stop affecting liability after `2035`, so these matches are at
+    least partly an implementation caveat.
+  - `option2` and `option3` match in `2100`, but the active senior-deduction
+    extension in `policyengine-us` stops at `2099-12-31`, so the `2100`
+    equality is not a clean permanent-policy endpoint.
+- `option7` remains exactly zero in both the old and corrected paths.
+
+## Source Artifacts
+
+The local result CSVs used for these tables are:
+
+- `results/local_oact_saved_h5_2090_all_reforms.csv`
+- `results/local_oact_saved_h5_2100_all_reforms.csv`
+
+These CSVs are local runtime outputs under `results/` and are not tracked in
+git; this markdown file is the tracked summary.

--- a/analysis/saved_h5_representative_checks.md
+++ b/analysis/saved_h5_representative_checks.md
@@ -1,0 +1,43 @@
+# Saved-H5 Three-Year Checks
+
+These local checks compare reform scores from corrected long-run saved H5 datasets
+against the current `results/oact_static_current.csv` baseline-override outputs.
+
+Method:
+- Baseline datasets come from the `us-data-calibration-contract` worktree using
+  target source `oact_2025_08_05_provisional`.
+- Baseline scoring composes the `trustees-core-thresholds-v1` tax-assumption
+  reform from `policyengine_us_data/datasets/cps/long_term/tax_assumptions.py`.
+- Runs currently depend on the local `policyengine-us` wage-base fix from PR
+  `#7912`.
+
+Three-year spot checks:
+
+| Reform | Year | Revenue Impact New ($B) | Revenue Impact Old ($B) | Delta ($B) | OASDI TOB Delta ($B) | HI TOB Delta ($B) |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `option1` | 2075 | -1476.389 | -1500.710 | 24.321 | 12.790 | 11.532 |
+| `option8` | 2075 | 413.597 | 510.380 | -96.783 | -16.263 | -80.529 |
+| `option11` | 2075 | 79.129 | 105.036 | -25.906 | 1.933 | -27.839 |
+| `option1` | 2090 | -2634.736 | -2646.220 | 11.484 | 3.974 | 7.510 |
+| `option8` | 2090 | 922.182 | 859.300 | 62.882 | -31.711 | 94.594 |
+| `option11` | 2090 | 297.056 | 181.358 | 115.698 | -18.457 | 134.155 |
+| `option1` | 2100 | -3841.095 | -3852.810 | 11.715 | 7.356 | 4.359 |
+| `option11` | 2100 | 49.579 | 321.851 | -272.272 | -33.532 | -238.740 |
+| `option8` | 2100 | 855.222 | 1318.330 | -463.108 | -44.394 | -418.714 |
+
+Interpretation:
+- The corrected long-run baseline changes actual reform scores, not just baseline
+  TOB columns.
+- Repeal (`option1`) becomes less negative once corrected baseline TOB is lower.
+- Non-repeal options can also move materially, but the sign and magnitude are
+  not uniform across reforms or years.
+
+Caveats:
+- These are still spot checks, not a full rerun across all reforms and years.
+- The saved-H5 rescoring path is now usable for repeated year-level checks, but
+  the first baseline load for a new year is still expensive; the baseline cache
+  in `.cache/saved_h5_baselines/` is intended to amortize that cost.
+
+Source artifacts:
+- `results/local_oact_saved_h5_3year_checks.csv`
+- `results/local_oact_saved_h5_3year_checks_billions.csv`

--- a/scripts/score_saved_h5_reforms.py
+++ b/scripts/score_saved_h5_reforms.py
@@ -1,0 +1,539 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pandas as pd
+from policyengine_core.data import Dataset
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+
+DEFAULT_TAX_ASSUMPTION_FACTORY = "create_wage_indexed_core_thresholds_reform"
+DEFAULT_BASELINE_CACHE_DIR = REPO_ROOT / ".cache" / "saved_h5_baselines"
+DEFAULT_REQUIRED_PROFILE = "ss-payroll-tob"
+DEFAULT_REQUIRED_TARGET_SOURCE = "oact_2025_08_05_provisional"
+DEFAULT_REQUIRED_TAX_ASSUMPTION = "trustees-core-thresholds-v1"
+DEFAULT_MIN_CALIBRATION_QUALITY = "aggregate"
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _candidate_tax_assumption_modules() -> list[Path]:
+    candidates: list[Path] = []
+    env_module = os.environ.get("CRFB_TAX_ASSUMPTION_MODULE")
+    if env_module:
+        candidates.append(Path(env_module).expanduser())
+    candidates.extend(
+        [
+            Path.home()
+            / ".codex-worktrees"
+            / "us-data-calibration-contract"
+            / "policyengine_us_data"
+            / "datasets"
+            / "cps"
+            / "long_term"
+            / "tax_assumptions.py",
+            REPO_ROOT.parent
+            / "policyengine-us-data"
+            / "policyengine_us_data"
+            / "datasets"
+            / "cps"
+            / "long_term"
+            / "tax_assumptions.py",
+        ]
+    )
+    return candidates
+
+
+def resolve_tax_assumption_module(module_path: str | None) -> Path:
+    if module_path:
+        path = Path(module_path).expanduser().resolve()
+        if not path.exists():
+            raise FileNotFoundError(path)
+        return path
+
+    for candidate in _candidate_tax_assumption_modules():
+        if candidate.exists():
+            return candidate.resolve()
+
+    raise FileNotFoundError(
+        "Could not resolve a tax assumption module. Pass --tax-assumption-module "
+        "or set CRFB_TAX_ASSUMPTION_MODULE."
+    )
+
+
+def _find_git_repo_root(path: Path) -> Path | None:
+    current = path if path.is_dir() else path.parent
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def policyengine_us_fingerprint() -> dict[str, object]:
+    import policyengine_us
+
+    package_file = Path(policyengine_us.__file__).resolve()
+    fingerprint: dict[str, object] = {
+        "package_file": str(package_file),
+        "package_file_sha256": _sha256_file(package_file),
+        "package_mtime_ns": package_file.stat().st_mtime_ns,
+        "package_size": package_file.stat().st_size,
+        "version": getattr(policyengine_us, "__version__", None),
+    }
+    repo_root = _find_git_repo_root(package_file)
+    if repo_root is None:
+        return fingerprint
+
+    fingerprint["repo_root"] = str(repo_root)
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if head.returncode == 0:
+        fingerprint["git_head"] = head.stdout.strip()
+
+    status = subprocess.run(
+        ["git", "status", "--porcelain=v1"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if status.returncode == 0:
+        dirty_entries = []
+        for line in status.stdout.splitlines():
+            if not line:
+                continue
+            rel_path = line[3:]
+            if " -> " in rel_path:
+                rel_path = rel_path.split(" -> ", 1)[1]
+            candidate = repo_root / rel_path
+            entry: dict[str, object] = {"status": line[:2], "path": rel_path}
+            if candidate.exists():
+                stat = candidate.stat()
+                entry["mtime_ns"] = stat.st_mtime_ns
+                entry["size"] = stat.st_size
+            dirty_entries.append(entry)
+        fingerprint["git_dirty_entries"] = dirty_entries
+
+    return fingerprint
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Score CRFB reforms on saved H5 datasets, optionally composing in a "
+            "baseline tax-assumption reform and comparing against an existing results CSV."
+        )
+    )
+    parser.add_argument(
+        "--dataset",
+        action="append",
+        required=True,
+        help=(
+            "Dataset spec in the form label=/absolute/path/to/<year>.h5. "
+            "The year is inferred from the H5 filename stem."
+        ),
+    )
+    parser.add_argument(
+        "--reform",
+        action="append",
+        required=True,
+        help="Reform ID to score, e.g. option1. Repeatable.",
+    )
+    parser.add_argument(
+        "--scoring-type",
+        default="static",
+        choices=["static", "dynamic"],
+        help="CRFB scoring type to use when building the reform.",
+    )
+    parser.add_argument(
+        "--tax-assumption-module",
+        help=(
+            "Path to the Python module defining the baseline tax-assumption reform "
+            "factory. If omitted, the script will try common local checkouts."
+        ),
+    )
+    parser.add_argument(
+        "--tax-assumption-factory",
+        default=DEFAULT_TAX_ASSUMPTION_FACTORY,
+        help="Factory function name inside --tax-assumption-module.",
+    )
+    parser.add_argument(
+        "--tax-assumption-start-year",
+        type=int,
+        default=2035,
+        help="Start year passed to the baseline tax-assumption reform factory.",
+    )
+    parser.add_argument(
+        "--tax-assumption-end-year",
+        type=int,
+        default=2100,
+        help="End year passed to the baseline tax-assumption reform factory.",
+    )
+    parser.add_argument(
+        "--compare-csv",
+        help="Optional existing CRFB results CSV to compare against.",
+    )
+    parser.add_argument(
+        "--compare-units",
+        default="billions",
+        choices=["billions", "dollars"],
+        help=(
+            "Units used by --compare-csv impact columns. "
+            "Legacy CRFB result CSVs are in billions."
+        ),
+    )
+    parser.add_argument(
+        "--baseline-cache-dir",
+        default=str(DEFAULT_BASELINE_CACHE_DIR),
+        help="Directory for caching baseline summaries keyed by dataset and tax assumption.",
+    )
+    parser.add_argument(
+        "--output",
+        help="Optional output CSV path. Defaults to stdout only.",
+    )
+    parser.add_argument(
+        "--required-profile",
+        default=DEFAULT_REQUIRED_PROFILE,
+        help="Expected calibration profile name recorded in the saved-H5 metadata.",
+    )
+    parser.add_argument(
+        "--required-target-source",
+        default=DEFAULT_REQUIRED_TARGET_SOURCE,
+        help="Expected target source name recorded in the saved-H5 metadata.",
+    )
+    parser.add_argument(
+        "--required-tax-assumption",
+        default=DEFAULT_REQUIRED_TAX_ASSUMPTION,
+        help="Expected tax assumption name recorded in the saved-H5 metadata.",
+    )
+    parser.add_argument(
+        "--minimum-calibration-quality",
+        default=DEFAULT_MIN_CALIBRATION_QUALITY,
+        choices=["aggregate", "approximate", "exact"],
+        help="Minimum calibration quality required in the saved-H5 metadata.",
+    )
+    return parser.parse_args()
+
+
+def load_tax_assumption_reform(
+    module_path: Path, factory_name: str, start_year: int, end_year: int
+):
+    spec = importlib.util.spec_from_file_location("tax_assumptions", module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load tax assumption module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    factory = getattr(module, factory_name)
+    return factory(start_year=start_year, end_year=end_year)
+
+
+def parse_dataset_spec(spec: str) -> tuple[str, Path, int]:
+    if "=" not in spec:
+        raise ValueError(f"Invalid dataset spec '{spec}'. Expected label=/path/to/year.h5")
+    label, raw_path = spec.split("=", 1)
+    path = Path(raw_path).expanduser().resolve()
+    if not path.exists():
+        raise FileNotFoundError(path)
+    try:
+        year = int(path.stem)
+    except ValueError as exc:
+        raise ValueError(
+            f"Could not infer year from dataset filename '{path.name}'. "
+            "Use files named like 2075.h5."
+        ) from exc
+    return label, path, year
+
+
+def resolve_dataset_year(
+    dataset_path: Path,
+    *,
+    inferred_year: int,
+    metadata: dict[str, object],
+) -> int:
+    metadata_year = metadata.get("year")
+    if metadata_year is None:
+        return inferred_year
+
+    metadata_year = int(metadata_year)
+    if metadata_year != inferred_year:
+        raise ValueError(
+            f"Dataset {dataset_path} filename implies year {inferred_year}, "
+            f"but metadata records year {metadata_year}."
+        )
+    return metadata_year
+
+
+def baseline_cache_path(
+    *,
+    dataset_path: Path,
+    module_path: Path,
+    module_sha256: str,
+    policyengine_fingerprint: dict[str, object],
+    factory_name: str,
+    start_year: int,
+    end_year: int,
+    cache_dir: str,
+) -> Path:
+    stat = dataset_path.stat()
+    key = json.dumps(
+        {
+            "dataset_path": str(dataset_path),
+            "dataset_size": stat.st_size,
+            "dataset_mtime_ns": stat.st_mtime_ns,
+            "module_path": str(module_path),
+            "module_sha256": module_sha256,
+            "factory_name": factory_name,
+            "start_year": start_year,
+            "end_year": end_year,
+            "policyengine_us": policyengine_fingerprint,
+        },
+        sort_keys=True,
+    ).encode("utf-8")
+    digest = hashlib.sha256(key).hexdigest()
+    return Path(cache_dir).expanduser().resolve() / f"{digest}.json"
+
+
+def load_or_compute_baseline(
+    *,
+    year: int,
+    dataset: Dataset,
+    dataset_path: Path,
+    baseline_reform,
+    module_path: Path,
+    module_sha256: str,
+    policyengine_fingerprint: dict[str, object],
+    factory_name: str,
+    start_year: int,
+    end_year: int,
+    cache_dir: str,
+    load_baseline_fn,
+    baseline_result_type,
+):
+    cache_path = baseline_cache_path(
+        dataset_path=dataset_path,
+        module_path=module_path,
+        module_sha256=module_sha256,
+        policyengine_fingerprint=policyengine_fingerprint,
+        factory_name=factory_name,
+        start_year=start_year,
+        end_year=end_year,
+        cache_dir=cache_dir,
+    )
+    if cache_path.exists():
+        payload = json.loads(cache_path.read_text(encoding="utf-8"))
+        print(f"  Loaded baseline cache {cache_path}", flush=True)
+        return baseline_result_type(**payload)
+
+    baseline = load_baseline_fn(
+        year=year,
+        dataset_name=dataset,
+        baseline_reform=baseline_reform,
+    )
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        json.dumps(
+            {
+                "revenue": baseline.revenue,
+                "tob_medicare_hi": baseline.tob_medicare_hi,
+                "tob_oasdi": baseline.tob_oasdi,
+                "tob_total": baseline.tob_total,
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    print(f"  Wrote baseline cache {cache_path}", flush=True)
+    return baseline
+
+
+def build_rows(args: argparse.Namespace) -> pd.DataFrame:
+    from year_runner import (
+        BaselineResult,
+        BATCH_EMPLOYER_NET_REFORMS,
+        compute_reform_result,
+        get_reform_lookups,
+        load_baseline,
+    )
+    from runtime_config import validate_dataset_contract
+
+    tax_assumption_module = resolve_tax_assumption_module(args.tax_assumption_module)
+    module_sha256 = _sha256_file(tax_assumption_module)
+    policyengine_fingerprint = policyengine_us_fingerprint()
+
+    baseline_reform = load_tax_assumption_reform(
+        tax_assumption_module,
+        args.tax_assumption_factory,
+        args.tax_assumption_start_year,
+        args.tax_assumption_end_year,
+    )
+    reform_functions, dynamic_functions = get_reform_lookups()
+
+    rows = []
+    for dataset_spec in args.dataset:
+        label, dataset_path, inferred_year = parse_dataset_spec(dataset_spec)
+        metadata = validate_dataset_contract(
+            dataset_path,
+            required_profile=args.required_profile,
+            minimum_calibration_quality=args.minimum_calibration_quality,
+            required_target_source=args.required_target_source,
+            required_tax_assumption=args.required_tax_assumption,
+            reject_aggregate=False,
+            allow_unvalidated=False,
+        )
+        year = resolve_dataset_year(
+            dataset_path,
+            inferred_year=inferred_year,
+            metadata=metadata,
+        )
+        print(f"Dataset {label}: {dataset_path} (year {year})", flush=True)
+        dataset = Dataset.from_file(str(dataset_path))
+        baseline_start = time.time()
+        baseline = load_or_compute_baseline(
+            year=year,
+            dataset=dataset,
+            dataset_path=dataset_path,
+            baseline_reform=baseline_reform,
+            module_path=tax_assumption_module,
+            module_sha256=module_sha256,
+            policyengine_fingerprint=policyengine_fingerprint,
+            factory_name=args.tax_assumption_factory,
+            start_year=args.tax_assumption_start_year,
+            end_year=args.tax_assumption_end_year,
+            cache_dir=args.baseline_cache_dir,
+            load_baseline_fn=load_baseline,
+            baseline_result_type=BaselineResult,
+        )
+        print(
+            "  Baseline loaded in "
+            f"{time.time() - baseline_start:.1f}s "
+            f"(revenue ${baseline.revenue / 1e9:.2f}B, "
+            f"OASDI TOB ${baseline.tob_oasdi / 1e9:.2f}B, "
+            f"HI TOB ${baseline.tob_medicare_hi / 1e9:.2f}B)"
+            ,
+            flush=True,
+        )
+        for reform_id in args.reform:
+            reform_start = time.time()
+            print(f"  Scoring {reform_id}...", flush=True)
+            result = compute_reform_result(
+                reform_id=reform_id,
+                year=year,
+                scoring_type=args.scoring_type,
+                dataset_name=dataset,
+                baseline=baseline,
+                reform_functions=reform_functions,
+                dynamic_functions=dynamic_functions,
+                employer_net_reforms=BATCH_EMPLOYER_NET_REFORMS,
+                default_net_impact_mode="direct",
+                baseline_reform=baseline_reform,
+            )
+            result["dataset_label"] = label
+            result["dataset_path"] = str(dataset_path)
+            rows.append(result)
+            print(
+                "    Done in "
+                f"{time.time() - reform_start:.1f}s "
+                f"(revenue ${result['revenue_impact'] / 1e9:+.2f}B, "
+                f"OASDI ${result['tob_oasdi_impact'] / 1e9:+.2f}B, "
+                f"HI ${result['tob_medicare_hi_impact'] / 1e9:+.2f}B)"
+                ,
+                flush=True,
+            )
+            if args.output:
+                partial_df = pd.DataFrame(rows)
+                output_path = Path(args.output)
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                partial_df.to_csv(output_path, index=False, float_format="%.10f")
+                print(f"    Wrote partial results to {output_path}", flush=True)
+
+    df = pd.DataFrame(rows)
+    ordered_columns = [
+        "dataset_label",
+        "dataset_path",
+        "reform_name",
+        "year",
+        "baseline_revenue",
+        "reform_revenue",
+        "revenue_impact",
+        "baseline_tob_oasdi",
+        "reform_tob_oasdi",
+        "tob_oasdi_impact",
+        "baseline_tob_medicare_hi",
+        "reform_tob_medicare_hi",
+        "tob_medicare_hi_impact",
+        "baseline_tob_total",
+        "reform_tob_total",
+        "tob_total_impact",
+        "scoring_type",
+    ]
+    extra_columns = [column for column in df.columns if column not in ordered_columns]
+    return df[ordered_columns + extra_columns]
+
+
+def maybe_compare(
+    df: pd.DataFrame,
+    compare_csv: str | None,
+    *,
+    compare_units: str,
+) -> pd.DataFrame:
+    if not compare_csv:
+        return df
+    compare = pd.read_csv(compare_csv)
+    compare_columns = [
+        "reform_name",
+        "year",
+        "revenue_impact",
+        "tob_oasdi_impact",
+        "tob_medicare_hi_impact",
+    ]
+    compare = compare[compare_columns].rename(
+        columns={column: f"{column}_old" for column in compare_columns if column not in {"reform_name", "year"}}
+    )
+    unit_scale = 1e9 if compare_units == "billions" else 1.0
+    for column in ["revenue_impact_old", "tob_oasdi_impact_old", "tob_medicare_hi_impact_old"]:
+        compare[column] = compare[column] * unit_scale
+    merged = df.merge(compare, on=["reform_name", "year"], how="left", validate="many_to_one")
+    for column in ["revenue_impact", "tob_oasdi_impact", "tob_medicare_hi_impact"]:
+        merged[f"{column}_delta"] = merged[column] - merged[f"{column}_old"]
+    return merged
+
+
+def main() -> None:
+    args = parse_args()
+    df = build_rows(args)
+    df = maybe_compare(df, args.compare_csv, compare_units=args.compare_units)
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(output_path, index=False, float_format="%.10f")
+        print(f"Wrote {output_path}", flush=True)
+
+    print(df.to_json(orient="records", indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/reforms.py
+++ b/src/reforms.py
@@ -842,10 +842,14 @@ def get_option2_reform():
 
 
 def get_option3_reform():
-    """Option 3: 85% Taxation with Permanent Senior Deduction Extension.
+    """Option 3: 85% Taxation with Senior Deduction Extension.
 
-    Combines taxation of 85% of benefits with a permanent extension
-    of the senior deduction that would otherwise expire in 2028.
+    Intended policy: combine taxation of 85% of benefits with a permanent
+    extension of the senior deduction that would otherwise expire in 2028.
+
+    Caveat: the current `policyengine-us` implementation extends the senior
+    deduction only through `2099-12-31`, so `2100` results should not be
+    interpreted as a true permanent-policy endpoint.
     """
     return Reform.from_dict(get_option3_dict(), country_id="us")
 

--- a/tests/test_saved_h5_rescoring.py
+++ b/tests/test_saved_h5_rescoring.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "score_saved_h5_reforms.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "score_saved_h5_reforms", SCRIPT_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_baseline_cache_path_includes_module_digest_and_policyengine_fingerprint(
+    tmp_path,
+):
+    module = _load_script_module()
+    dataset_path = tmp_path / "2090.h5"
+    dataset_path.write_text("", encoding="utf-8")
+
+    path_a = module.baseline_cache_path(
+        dataset_path=dataset_path,
+        module_path=tmp_path / "tax_assumptions.py",
+        module_sha256="aaa",
+        policyengine_fingerprint={"git_head": "one"},
+        factory_name="factory",
+        start_year=2035,
+        end_year=2100,
+        cache_dir=str(tmp_path / "cache"),
+    )
+    path_b = module.baseline_cache_path(
+        dataset_path=dataset_path,
+        module_path=tmp_path / "tax_assumptions.py",
+        module_sha256="bbb",
+        policyengine_fingerprint={"git_head": "one"},
+        factory_name="factory",
+        start_year=2035,
+        end_year=2100,
+        cache_dir=str(tmp_path / "cache"),
+    )
+    path_c = module.baseline_cache_path(
+        dataset_path=dataset_path,
+        module_path=tmp_path / "tax_assumptions.py",
+        module_sha256="aaa",
+        policyengine_fingerprint={"git_head": "two"},
+        factory_name="factory",
+        start_year=2035,
+        end_year=2100,
+        cache_dir=str(tmp_path / "cache"),
+    )
+
+    assert path_a != path_b
+    assert path_a != path_c
+
+
+def test_resolve_dataset_year_rejects_filename_metadata_mismatch(tmp_path):
+    module = _load_script_module()
+    dataset_path = tmp_path / "2090.h5"
+    dataset_path.write_text("", encoding="utf-8")
+
+    try:
+        module.resolve_dataset_year(
+            dataset_path,
+            inferred_year=2090,
+            metadata={"year": 2100},
+        )
+    except ValueError as error:
+        assert "filename implies year 2090" in str(error)
+        assert "metadata records year 2100" in str(error)
+    else:
+        raise AssertionError("Expected a filename/metadata year mismatch error")


### PR DESCRIPTION
## Summary

This draft is the current integration branch for corrected long-run TOB work in
`crfb-tob-impacts`.

It currently combines three related tracks:

- rebuild the TOB baseline / post-OBBBA rerun harness around source-documented inputs
- add a saved-H5 rescoring workflow for checking reforms against corrected long-run microdata
- track long-run rescoring findings and reproducibility caveats

This is still an integration branch, not the final merge unit. The dashboard rewrite
that also lives on this branch should be split into its own PR before merge.

## What is in this branch

### 1. TOB baseline harness and rerun plumbing

- generated TOB baseline flow driven by explicit source files and validators
- post-OBBBA baseline application rewired around that generated baseline
- consolidated trust-fund allocation logic used by Python and the dashboard
- reproducibility notes for the current stack

### 2. Saved-H5 rescoring workflow

- `scripts/score_saved_h5_reforms.py`
- `src/year_runner.py` support for rescoring on saved H5 datasets
- composed baseline tax reform support for corrected long-run checks
- baseline caching for repeated checks on the same long-run year
- unit-aware comparison against legacy CRFB result CSVs
- saved-H5 contract validation for:
  - calibration profile
  - calibration quality
  - target source
  - tax assumption
  - filename year vs metadata year

### 3. Tracked long-run findings

- representative corrected-vs-old checks for `2075`, `2090`, and `2100`
- full all-reforms summaries for `2090` and `2100`
- tracked findings notes and year-grid recommendation

## Current findings

The key result so far is that `results/oact_static_current.csv` is stale for
long-run scoring. Rescoring on corrected saved H5 microdata changes actual
reform impacts, not just baseline TOB columns.

Tracked notes:
- `analysis/saved_h5_representative_checks.md`
- `analysis/saved_h5_all_reforms_2090_2100.md`
- `analysis/long_run_rescoring_findings.md`

Important interpretation caveat:
- `option5`, `option6`, and `option12` appear to converge to the same long-run policy state.
- But some other far-tail equalities are not clean economic convergence under the current dependency stack:
  - the Social Security credit path appears to stop affecting liability after `2035`, which affects `option4` and `option11`
  - the active senior-deduction extension stops at `2099-12-31`, so `2100` `option3` results are not a true permanent-policy endpoint

## Important caveats

- Current long-run checks still depend on the local `policyengine-us` wage-base fix from `policyengine-us#7912`.
- The branch remains broad and should stay draft until mergeable infrastructure is separated from dashboard work and refreshed result outputs.
- Local `results/local_oact_saved_h5_*` CSVs referenced in the findings notes are runtime artifacts, not tracked repo files.

## Supersession / cleanup

This PR supersedes the older draft PRs that carried earlier slices of the same work:
- #66
- #54
- #50

## Validation used on this branch

- `uv run --extra dev ruff check src/year_runner.py scripts/score_saved_h5_reforms.py src/tob_baseline.py scripts/build_tob_baseline.py scripts/validate_tob_baseline.py`
- `python3 -m py_compile src/year_runner.py scripts/score_saved_h5_reforms.py src/tob_baseline.py scripts/build_tob_baseline.py scripts/validate_tob_baseline.py`
- `uv run pytest tests/test_tob_baseline.py tests/test_runtime_config.py tests/test_trust_fund_allocation.py`
- `uv run pytest tests/test_runtime_config.py tests/test_tob_baseline.py tests/test_saved_h5_rescoring.py -q`
- local saved-H5 checks for `2075`, `2090`, and `2100`
