### PR TITLE
Install TinyTeX for Quarto PDF deploy

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -64,6 +64,8 @@ jobs:
       - name: Setup Quarto
         if: steps.config.outputs.configured == 'true'
         uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          tinytex: true
 
       - name: Install Vercel CLI
         if: steps.config.outputs.configured == 'true'
@@ -175,6 +177,8 @@ jobs:
 
       - name: Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          tinytex: true
 
       - name: Install Vercel CLI
         run: npm install --global vercel@latest


### PR DESCRIPTION
## Summary
- install TinyTeX in the Vercel deploy workflow so Quarto can render the citable PDF paper
- apply the same setup to preview and production deploy jobs

## Verification
- confirmed production deploy skipped PDF because GitHub Actions had no TeX installation
- workflow-only change