### PR TITLE
Add reform explanations to dashboard

### DIFF
--- a/dashboard/src/components/dashboard-shell.tsx
+++ b/dashboard/src/components/dashboard-shell.tsx
@@ -245,6 +245,68 @@ function SeriesChart({
   );
 }
 
+function ReformBrief({
+  reform,
+  scoringType,
+}: {
+  reform: ReformMeta;
+  scoringType: ScoringType;
+}) {
+  return (
+    <motion.section
+      key={`${reform.id}-${scoringType}`}
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: "easeOut" }}
+      className="rounded-[var(--pe-radius-feature)] border border-[var(--pe-color-border-light)] bg-white px-5 py-5 shadow-[0_18px_48px_rgba(16,24,40,0.06)]"
+    >
+      <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--pe-color-text-tertiary)]">
+            Selected reform · {reform.category}
+          </p>
+          <h3 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-[var(--pe-color-text-title)]">
+            {reform.name}
+          </h3>
+          <p className="mt-3 text-base leading-7 text-[var(--pe-color-text-secondary)]">
+            {reform.description}
+          </p>
+        </div>
+        <div className="shrink-0 rounded-full bg-[var(--pe-color-primary-50)] px-4 py-2 text-sm font-semibold text-[var(--pe-color-primary-800)]">
+          {scoringType === "dynamic" ? "Conventional dynamic view" : "Static view"}
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-4 border-t border-[var(--pe-color-border-light)] pt-5 lg:grid-cols-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--pe-color-text-tertiary)]">
+            What changes
+          </p>
+          <p className="mt-2 text-sm leading-6 text-[var(--pe-color-text-secondary)]">
+            {reform.mechanism}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--pe-color-text-tertiary)]">
+            Baseline context
+          </p>
+          <p className="mt-2 text-sm leading-6 text-[var(--pe-color-text-secondary)]">
+            {reform.baseline}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[var(--pe-color-text-tertiary)]">
+            How to read it
+          </p>
+          <p className="mt-2 text-sm leading-6 text-[var(--pe-color-text-secondary)]">
+            {reform.interpretation} {reform.scoringNote}
+          </p>
+        </div>
+      </div>
+    </motion.section>
+  );
+}
+
 export function DashboardShell() {
   const [activeTab, setActiveTab] = useState<DashboardTab>("reforms");
   const [selectedReform, setSelectedReform] = useState("option1");
@@ -595,6 +657,10 @@ export function DashboardShell() {
               </div>
             </div>
           </section>
+          ) : null}
+
+          {activeTab === "reforms" ? (
+            <ReformBrief reform={reform} scoringType={scoringType} />
           ) : null}
 
           {activeTab === "paper" ? (

--- a/dashboard/src/lib/reforms.ts
+++ b/dashboard/src/lib/reforms.ts
@@ -3,6 +3,11 @@ export interface ReformMeta {
   name: string;
   shortName: string;
   description: string;
+  category: string;
+  mechanism: string;
+  baseline: string;
+  interpretation: string;
+  scoringNote: string;
 }
 
 export interface ExternalEstimate {
@@ -20,6 +25,15 @@ export const REFORMS: ReformMeta[] = [
     shortName: "Full repeal",
     description:
       "Complete elimination of Social Security benefit income taxation starting in 2026.",
+    category: "Direct taxability",
+    mechanism:
+      "Repeals federal income taxation of Social Security benefits beginning in 2026.",
+    baseline:
+      "Scored against current law, including the temporary senior deduction and its scheduled expiration after 2028.",
+    interpretation:
+      "Negative values represent lost income-tax revenue currently credited to the OASDI and HI trust funds.",
+    scoringNote:
+      "Static and conventional dynamic results are available for the full 2026-2100 window.",
   },
   {
     id: "option2",
@@ -27,6 +41,15 @@ export const REFORMS: ReformMeta[] = [
     shortName: "85% taxation",
     description:
       "Tax 85% of all Social Security benefits regardless of income level.",
+    category: "Direct taxability",
+    mechanism:
+      "Eliminates the current-law income thresholds and applies the top statutory 85 percent inclusion rate to all beneficiaries.",
+    baseline:
+      "Scored against current-law benefit taxation rules, where taxable benefits phase in only above combined-income thresholds.",
+    interpretation:
+      "Positive values show the added revenue from expanding the taxable-benefit base below the current thresholds.",
+    scoringNote:
+      "Static and conventional dynamic results are available for the full 2026-2100 window.",
   },
   {
     id: "option3",
@@ -34,6 +57,15 @@ export const REFORMS: ReformMeta[] = [
     shortName: "85% + deduction",
     description:
       "Apply 85% taxation and permanently extend the bonus senior deduction.",
+    category: "Senior relief",
+    mechanism:
+      "Combines uniform 85 percent benefit taxation with permanent extension of the temporary bonus senior deduction.",
+    baseline:
+      "The baseline senior deduction expires after 2028; this reform keeps that relief in place indefinitely.",
+    interpretation:
+      "Results combine added taxable-benefit revenue with the offsetting cost of extending the senior deduction.",
+    scoringNote:
+      "Static and conventional dynamic results are available for the full 2026-2100 window.",
   },
   {
     id: "option4",
@@ -41,6 +73,15 @@ export const REFORMS: ReformMeta[] = [
     shortName: "$500 credit",
     description:
       "Keep 85% taxation and replace the bonus senior deduction with a $500 nonrefundable credit.",
+    category: "Senior relief",
+    mechanism:
+      "Applies uniform 85 percent benefit taxation, repeals the bonus senior deduction, and creates a $500 nonrefundable credit tied to Social Security tax liability.",
+    baseline:
+      "Scored against current law with the temporary senior deduction still present through 2028.",
+    interpretation:
+      "The credit targets relief more directly than a deduction, so revenue effects reflect both the broader tax base and the capped credit offset.",
+    scoringNote:
+      "Static and conventional dynamic results are available for the full 2026-2100 window.",
   },
   {
     id: "option5",
@@ -48,6 +89,15 @@ export const REFORMS: ReformMeta[] = [
     shortName: "Roth swap",
     description:
       "Tax employer payroll contributions instead of benefits starting in 2026.",
+    category: "Employer payroll-tax swap",
+    mechanism:
+      "Eliminates Social Security benefit taxation and instead treats employer payroll-tax contributions as taxable compensation.",
+    baseline:
+      "Scored against current-law benefit taxation and payroll-tax treatment.",
+    interpretation:
+      "This is a structural tax-base shift from retirees toward workers, not just a change in taxable-benefit inclusion.",
+    scoringNote:
+      "Static and conventional dynamic results are available; trust-fund allocation follows the explicit OASDI/HI net-impact logic.",
   },
   {
     id: "option6",
@@ -55,12 +105,30 @@ export const REFORMS: ReformMeta[] = [
     shortName: "Phased Roth",
     description:
       "Gradually transition from taxing benefits to taxing employer contributions.",
+    category: "Employer payroll-tax swap",
+    mechanism:
+      "Phases in taxation of employer payroll-tax contributions while phasing out benefit taxation over time.",
+    baseline:
+      "Scored against current law, with transition years comparing a partial payroll-tax inclusion against remaining benefit taxation.",
+    interpretation:
+      "The time path matters: early years show the phase-in, while later years converge toward the structural swap.",
+    scoringNote:
+      "Static and conventional dynamic results are available; trust-fund allocation follows the explicit OASDI/HI net-impact logic.",
   },
   {
     id: "option7",
     name: "Eliminate Bonus Senior Deduction",
     shortName: "No senior deduction",
     description: "Eliminate the bonus senior deduction.",
+    category: "Senior relief",
+    mechanism:
+      "Repeals the temporary bonus senior deduction without otherwise changing Social Security benefit-taxation rules.",
+    baseline:
+      "The baseline deduction is temporary and expires after 2028, so this option mainly affects 2026-2028.",
+    interpretation:
+      "Positive values represent higher income-tax revenue from removing the temporary deduction.",
+    scoringNote:
+      "Static and conventional dynamic results are available; this is treated as a general-revenue change rather than a direct OASDI/HI benefit-tax split.",
   },
   {
     id: "option8",
@@ -68,6 +136,15 @@ export const REFORMS: ReformMeta[] = [
     shortName: "100% taxation",
     description:
       "Tax 100% of all Social Security benefits regardless of income.",
+    category: "Direct taxability",
+    mechanism:
+      "Eliminates thresholds and includes all Social Security benefits in taxable income.",
+    baseline:
+      "Scored against current-law thresholds and the current maximum 85 percent taxable-benefit inclusion rate.",
+    interpretation:
+      "This is the broadest direct benefit-taxation option, so positive revenue effects are larger than under 85, 90, or 95 percent inclusion.",
+    scoringNote:
+      "Static and conventional dynamic results are available for the full 2026-2100 window.",
   },
   {
     id: "option9",
@@ -75,6 +152,15 @@ export const REFORMS: ReformMeta[] = [
     shortName: "90% taxation",
     description:
       "Tax 90% of all Social Security benefits regardless of income.",
+    category: "Direct taxability",
+    mechanism:
+      "Eliminates thresholds and includes 90 percent of every beneficiary's Social Security benefits in taxable income.",
+    baseline:
+      "Scored against current-law thresholds and the current maximum 85 percent taxable-benefit inclusion rate.",
+    interpretation:
+      "Revenue effects sit between uniform 85 percent taxation and broader 95 or 100 percent inclusion.",
+    scoringNote:
+      "Static and conventional dynamic results are available for the full 2026-2100 window.",
   },
   {
     id: "option10",
@@ -82,6 +168,15 @@ export const REFORMS: ReformMeta[] = [
     shortName: "95% taxation",
     description:
       "Tax 95% of all Social Security benefits regardless of income.",
+    category: "Direct taxability",
+    mechanism:
+      "Eliminates thresholds and includes 95 percent of every beneficiary's Social Security benefits in taxable income.",
+    baseline:
+      "Scored against current-law thresholds and the current maximum 85 percent taxable-benefit inclusion rate.",
+    interpretation:
+      "Revenue effects are larger than under 85 or 90 percent inclusion but smaller than taxing all benefits.",
+    scoringNote:
+      "Static and conventional dynamic results are available for the full 2026-2100 window.",
   },
   {
     id: "option11",
@@ -89,6 +184,15 @@ export const REFORMS: ReformMeta[] = [
     shortName: "$700 credit",
     description:
       "Keep 85% taxation and replace the senior deduction with a phased-out $700 nonrefundable credit.",
+    category: "Senior relief",
+    mechanism:
+      "Applies uniform 85 percent benefit taxation, repeals the bonus senior deduction, and creates a phased-out $700 nonrefundable Social Security credit.",
+    baseline:
+      "Scored against current law with the temporary senior deduction through 2028 and no permanent replacement credit.",
+    interpretation:
+      "The larger credit provides more offset than the $500 design and phases out above higher incomes.",
+    scoringNote:
+      "Static and conventional dynamic results are available for the full 2026-2100 window.",
   },
   {
     id: "option12",
@@ -96,6 +200,15 @@ export const REFORMS: ReformMeta[] = [
     shortName: "Extended Roth",
     description:
       "Tax employer payroll contributions immediately and phase out benefit taxation from 2029 to 2062.",
+    category: "Employer payroll-tax swap",
+    mechanism:
+      "Taxes employer payroll-tax contributions immediately while phasing out benefit taxation over an extended schedule.",
+    baseline:
+      "Scored against current law, with the OASDI share of benefit taxation phased out before the HI share.",
+    interpretation:
+      "The late-horizon sign can differ from the first decade because the payroll-tax inclusion and benefit-tax phaseout operate on different bases.",
+    scoringNote:
+      "Static and conventional dynamic results are available; trust-fund allocation follows the explicit OASDI/HI net-impact logic.",
   },
   {
     id: "option13",
@@ -103,6 +216,15 @@ export const REFORMS: ReformMeta[] = [
     shortName: "Balanced fix",
     description:
       "Close projected trust fund gaps starting in 2035 using a 50/50 payroll-tax and benefit-cut package.",
+    category: "Special case",
+    mechanism:
+      "Combines proportional Social Security benefit reductions with Social Security and Medicare payroll-tax increases beginning in 2035.",
+    baseline:
+      "This is a stylized solvency baseline, not a standard reform scored against current law.",
+    interpretation:
+      "Read the dedicated Balanced Fix tab rather than comparing it directly with Options 1-12.",
+    scoringNote:
+      "Only static special-case results are included in the public release.",
   },
 ];
 


### PR DESCRIPTION
## Summary
- add structured explanation metadata for each dashboard reform option
- show a selected-reform brief above the result cards
- keep the brief synchronized with the selected scoring mode

## Checks
- bun run lint
- bun run build
- ./scripts/build_vercel_site.sh