### PR TITLE
Add multizone base path support

### DIFF
--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -1,8 +1,10 @@
 import type { NextConfig } from "next";
 
-const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "/us/taxation-of-benefits-reforms";
 
 const nextConfig: NextConfig = {
+  ...(basePath ? { basePath } : {}),
+  env: { NEXT_PUBLIC_BASE_PATH: basePath },
   output: "export",
   trailingSlash: true,
   basePath,

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   title: "Taxation of benefits reforms | PolicyEngine",
   description:
     "Interactive estimates for Social Security taxation-of-benefits reform options through 2100, commissioned by the Committee for a Responsible Federal Budget.",
-  icons: { icon: "/favicon.svg" },
+  icons: { icon: `${process.env.NEXT_PUBLIC_BASE_PATH || ""}/favicon.svg` },
 };
 
 export default function RootLayout({

--- a/dashboard/src/lib/dashboard-data.ts
+++ b/dashboard/src/lib/dashboard-data.ts
@@ -96,7 +96,7 @@ async function fetchCsv(path: string): Promise<string> {
 }
 
 async function loadHiTaxablePayroll(): Promise<Map<number, number>> {
-  const csvContent = await fetchCsv("/data/hi_taxable_payroll.csv");
+  const csvContent = await fetchCsv(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/data/hi_taxable_payroll.csv`);
   const parsed = Papa.parse<Record<string, string>>(csvContent, {
     header: true,
     skipEmptyLines: true,
@@ -113,7 +113,7 @@ async function loadHiTaxablePayroll(): Promise<Map<number, number>> {
 async function loadEconomicProjections(): Promise<Map<number, EconomicProjection>> {
   if (!projectionCache) {
     projectionCache = Promise.all([
-      fetchCsv("/data/ssa_economic_projections.csv"),
+      fetchCsv(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/data/ssa_economic_projections.csv`),
       loadHiTaxablePayroll(),
     ]).then(([csvContent, hiTaxablePayroll]) => {
       const parsed = Papa.parse<Record<string, string>>(csvContent, {
@@ -213,7 +213,7 @@ export async function loadDashboardData(
   allocationMode: AllocationMode,
 ): Promise<Record<string, YearlyImpact[]>> {
   const [csvContent, projections] = await Promise.all([
-    fetchCsv("/data/all_static_results.csv"),
+    fetchCsv(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/data/all_static_results.csv`),
     loadEconomicProjections(),
   ]);
 

--- a/dashboard/src/lib/option13-data.ts
+++ b/dashboard/src/lib/option13-data.ts
@@ -67,7 +67,7 @@ async function fetchCsv(path: string) {
 }
 
 export async function loadOption13Data(): Promise<Option13Data[]> {
-  const csvContent = await fetchCsv("/data/option13_balanced_fix.csv");
+  const csvContent = await fetchCsv(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/data/option13_balanced_fix.csv`);
   const parsed = Papa.parse<Record<string, string>>(csvContent, {
     header: true,
     skipEmptyLines: true,
@@ -109,7 +109,7 @@ export async function loadOption13Data(): Promise<Option13Data[]> {
 
 export async function loadTrusteesComparisonData(): Promise<TrusteesComparisonData[]> {
   const [csvContent, option13Data] = await Promise.all([
-    fetchCsv("/data/trustees_vs_pe_gaps_comparison.csv"),
+    fetchCsv(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/data/trustees_vs_pe_gaps_comparison.csv`),
     loadOption13Data(),
   ]);
   const parsed = Papa.parse<Record<string, string>>(csvContent, {


### PR DESCRIPTION
Adds a production base path for the PolicyEngine multizone mount and keeps local/root builds available with `NEXT_PUBLIC_BASE_PATH=` where the app uses Next.js.

Also prefixes root-relative public data/assets where needed so the zone loads correctly behind `policyengine.org` instead of only passing a framework build.

Verification:
- `git diff --check`