### PR TITLE
Allow dashboard-only Vercel builds

### DIFF
--- a/scripts/build_vercel_site.sh
+++ b/scripts/build_vercel_site.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 site_dir="$repo_root/.vercel-site"
-dashboard_base_path="${NEXT_PUBLIC_BASE_PATH:-}"
+dashboard_base_path="${NEXT_PUBLIC_BASE_PATH:-/us/taxation-of-benefits-reforms}"
 dashboard_target="$site_dir${dashboard_base_path:-/}"
 paper_target="$dashboard_target/paper"
 paper_output="$repo_root/paper/_build"
@@ -24,26 +24,25 @@ echo "  paper path: ${dashboard_base_path:-}/paper/"
 rm -rf "$site_dir"
 mkdir -p "$dashboard_target" "$paper_target"
 
-if ! command -v quarto >/dev/null 2>&1; then
-  echo "Quarto is required to build the citable paper at /paper/." >&2
-  exit 1
-fi
+if command -v quarto >/dev/null 2>&1; then
+  rm -rf "$paper_output"
+  quarto render "$repo_root/paper/index.qmd" --to html
 
-rm -rf "$paper_output"
-quarto render "$repo_root/paper/index.qmd" --to html
+  if [ ! -d "$paper_output" ]; then
+    echo "Could not find Quarto paper output." >&2
+    exit 1
+  fi
 
-if [ ! -d "$paper_output" ]; then
-  echo "Could not find Quarto paper output." >&2
-  exit 1
-fi
+  if quarto render "$repo_root/paper/index.qmd" --to pdf; then
+    echo "Rendered paper PDF."
+  else
+    echo "Paper PDF render skipped; HTML paper is still available." >&2
+  fi
 
-if quarto render "$repo_root/paper/index.qmd" --to pdf; then
-  echo "Rendered paper PDF."
+  cp -R "$paper_output/." "$paper_target/"
 else
-  echo "Paper PDF render skipped; HTML paper is still available." >&2
+  echo "Quarto unavailable; skipping paper build for dashboard-only Vercel deployment." >&2
 fi
-
-cp -R "$paper_output/." "$paper_target/"
 
 pushd "$repo_root/dashboard" >/dev/null
 NEXT_PUBLIC_BASE_PATH="$dashboard_base_path" bun run build


### PR DESCRIPTION
## Summary\n- default the Vercel dashboard build to the multizone base path\n- skip paper generation when Quarto is unavailable so dashboard-only deployments still publish\n\n## Verification\n- PATH="/Users/maxghenis/.bun/bin:/usr/bin:/bin:/usr/sbin:/sbin" NEXT_PUBLIC_BASE_PATH=/us/taxation-of-benefits-reforms ./scripts/build_vercel_site.sh