### PR TITLE
Fix duplicate header and double basePath on data fetches

### DIFF
--- a/dashboard/src/components/dashboard-shell.tsx
+++ b/dashboard/src/components/dashboard-shell.tsx
@@ -14,7 +14,7 @@ import {
 } from "recharts";
 import type { NameType, ValueType } from "recharts/types/component/DefaultTooltipContent";
 import { useEffect, useState } from "react";
-import { Header, logos, type NavItemConfig } from "@policyengine/ui-kit";
+import { logos, type NavItemConfig } from "@policyengine/ui-kit";
 
 import { ComparisonTable } from "@/components/comparison-table";
 import { MethodologySection } from "@/components/methodology-section";
@@ -506,13 +506,8 @@ export function DashboardShell() {
 
   return (
     <div className="min-h-screen bg-[var(--background)] text-[var(--pe-color-text-primary)]">
-      {!isEmbedded && (
-        <Header
-          navItems={PE_NAV_ITEMS}
-          logoSrc={logos.whiteWordmark}
-          logoHref={`${POLICYENGINE_BASE}/us`}
-        />
-      )}
+      {/* Site header is rendered by PolicyEngineShell in app/layout.tsx —
+          no need to render Header here. */}
 
       <motion.div
         initial={{ opacity: 0, y: 14 }}

--- a/dashboard/src/lib/dashboard-data.ts
+++ b/dashboard/src/lib/dashboard-data.ts
@@ -96,7 +96,7 @@ async function fetchCsv(path: string): Promise<string> {
 }
 
 async function loadHiTaxablePayroll(): Promise<Map<number, number>> {
-  const csvContent = await fetchCsv(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/data/hi_taxable_payroll.csv`);
+  const csvContent = await fetchCsv(`/data/hi_taxable_payroll.csv`);
   const parsed = Papa.parse<Record<string, string>>(csvContent, {
     header: true,
     skipEmptyLines: true,
@@ -113,7 +113,7 @@ async function loadHiTaxablePayroll(): Promise<Map<number, number>> {
 async function loadEconomicProjections(): Promise<Map<number, EconomicProjection>> {
   if (!projectionCache) {
     projectionCache = Promise.all([
-      fetchCsv(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/data/ssa_economic_projections.csv`),
+      fetchCsv(`/data/ssa_economic_projections.csv`),
       loadHiTaxablePayroll(),
     ]).then(([csvContent, hiTaxablePayroll]) => {
       const parsed = Papa.parse<Record<string, string>>(csvContent, {
@@ -213,7 +213,7 @@ export async function loadDashboardData(
   allocationMode: AllocationMode,
 ): Promise<Record<string, YearlyImpact[]>> {
   const [csvContent, projections] = await Promise.all([
-    fetchCsv(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/data/all_static_results.csv`),
+    fetchCsv(`/data/all_static_results.csv`),
     loadEconomicProjections(),
   ]);
 

--- a/dashboard/src/lib/option13-data.ts
+++ b/dashboard/src/lib/option13-data.ts
@@ -67,7 +67,7 @@ async function fetchCsv(path: string) {
 }
 
 export async function loadOption13Data(): Promise<Option13Data[]> {
-  const csvContent = await fetchCsv(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/data/option13_balanced_fix.csv`);
+  const csvContent = await fetchCsv(`/data/option13_balanced_fix.csv`);
   const parsed = Papa.parse<Record<string, string>>(csvContent, {
     header: true,
     skipEmptyLines: true,
@@ -109,7 +109,7 @@ export async function loadOption13Data(): Promise<Option13Data[]> {
 
 export async function loadTrusteesComparisonData(): Promise<TrusteesComparisonData[]> {
   const [csvContent, option13Data] = await Promise.all([
-    fetchCsv(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/data/trustees_vs_pe_gaps_comparison.csv`),
+    fetchCsv(`/data/trustees_vs_pe_gaps_comparison.csv`),
     loadOption13Data(),
   ]);
   const parsed = Papa.parse<Record<string, string>>(csvContent, {


### PR DESCRIPTION
Two regressions on /us/taxation-of-benefits-reforms:

**1. Duplicate header**: `dashboard-shell.tsx` rendered the ui-kit Header inside the page. With PolicyEngineShell now rendering the Header at the body root, two stacked PolicyEngine nav bars showed. Removed the in-page render.

**2. Double basePath**: `fetchCsv()` already prepends `NEXT_PUBLIC_BASE_PATH` internally, but every caller was inlining `${NEXT_PUBLIC_BASE_PATH}` again, so the final URL ended up like `/us/taxation-of-benefits-reforms/us/taxation-of-benefits-reforms/data/hi_taxable_payroll.csv` → 404. Now callers pass bare `/data/...` paths.

Verified locally: build clean, no TS warnings.