### PR TITLE
Hide 2026 baseline TOB cards

### DIFF
--- a/dashboard/src/components/baseline-assumptions-section.tsx
+++ b/dashboard/src/components/baseline-assumptions-section.tsx
@@ -799,12 +799,7 @@ export function BaselineAssumptionsSection() {
         </div>
       </section>
 
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <AssumptionMetric
-          label="2026 TOB baseline"
-          value={baseline2026 ? formatBillions(baseline2026.tobTotal) : "n/a"}
-          caption="Post-OBBBA OASDI plus HI benefit-tax revenue"
-        />
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
         <AssumptionMetric
           label="2100 TOB baseline"
           value={baseline2100 ? formatBillions(baseline2100.tobTotal) : "n/a"}

--- a/dashboard/src/components/dashboard-shell.tsx
+++ b/dashboard/src/components/dashboard-shell.tsx
@@ -474,7 +474,6 @@ export function DashboardShell() {
   const showAllocationToggle = ALLOCATION_ELIGIBLE_OPTIONS.includes(effectiveReformId);
   const isStaticOnlyReform = false;
   const estimates = EXTERNAL_ESTIMATES[effectiveReformId] ?? [];
-  const baseline2026 = selectedData.find((row) => row.year === 2026);
   const mobileViewValue =
     activeTab === "baseline"
         ? "baseline"
@@ -791,7 +790,7 @@ export function DashboardShell() {
               </section>
 
               {/* Metrics */}
-              <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <section className="grid gap-4 md:grid-cols-2">
                 <MetricTile
                   label="75-year effect"
                   value={formatValue(
@@ -818,13 +817,6 @@ export function DashboardShell() {
                   )}
                   tone={totals.tenYear >= 0 ? "positive" : "negative"}
                   caption="2026–2035 cumulative"
-                />
-                <MetricTile
-                  label="2026 baseline TOB"
-                  value={
-                    baseline2026 ? formatBillions(baseline2026.baselineTobTotal) : "n/a"
-                  }
-                  caption="Current-law baseline"
                 />
               </section>
 

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -249,6 +249,26 @@ def test_public_dashboard_hides_income_tax_diagnostic_card():
     assert "IncomeTaxPlausibilityChart" not in source
 
 
+def test_public_dashboard_hides_2026_baseline_tob_cards():
+    dashboard_shell = (
+        REPO_ROOT
+        / "dashboard"
+        / "src"
+        / "components"
+        / "dashboard-shell.tsx"
+    ).read_text(encoding="utf-8")
+    baseline_section = (
+        REPO_ROOT
+        / "dashboard"
+        / "src"
+        / "components"
+        / "baseline-assumptions-section.tsx"
+    ).read_text(encoding="utf-8")
+
+    assert "2026 baseline TOB" not in dashboard_shell
+    assert "2026 TOB baseline" not in baseline_section
+
+
 def test_baseline_assumption_public_audit_files_exist_and_cover_core_contract():
     for path in BASELINE_AUDIT_PUBLIC_FILES:
         assert path.exists(), f"Missing dashboard baseline audit artifact: {path.name}"


### PR DESCRIPTION
## Summary
- remove the 2026 baseline TOB metric tile from the reform dashboard
- remove the 2026 TOB baseline metric card from the baseline model tab
- add a release guard so those cards do not return

## Checks
- bun run lint
- bun run build
- uv run pytest tests/test_release_artifacts.py -q
- ./scripts/build_vercel_site.sh
- rg -n "2026 baseline TOB|2026 TOB baseline" .vercel-site dashboard/out dashboard/.next || true