### PR TITLE
Remove duplicate scoring badge

### DIFF
--- a/dashboard/src/components/dashboard-shell.tsx
+++ b/dashboard/src/components/dashboard-shell.tsx
@@ -747,11 +747,6 @@ export function DashboardShell() {
                       {reform.mechanism}
                     </p>
                   </div>
-                  <span className="inline-flex shrink-0 items-center rounded-full bg-[var(--pe-color-bg-secondary)] px-3 py-1 text-xs font-medium text-[var(--pe-color-text-secondary)]">
-                    {scoringType === "behavioral"
-                      ? "Labor-supply response"
-                      : "Static scoring"}
-                  </span>
                 </div>
               </section>
 


### PR DESCRIPTION
## Summary
- remove the duplicate static/labor-response badge from the reform header
- keep the scoring segmented control as the single visible mode indicator

## Tests
- cd dashboard && bun run lint
- cd dashboard && bun run build