### PR TITLE
Align CRFB methodology copy with current results

### DIFF
--- a/dashboard/src/components/methodology-section.tsx
+++ b/dashboard/src/components/methodology-section.tsx
@@ -148,7 +148,7 @@ export function MethodologySection() {
 
         <AccordionItem
           title="Scoring Approach"
-          summary="Static scoring is primary; current-contract labor-supply response results are pending."
+          summary="Static scoring is primary; behavioral labor-response results are supplemental."
         >
           <p>
             <strong>Static scoring:</strong> holds taxpayer behavior constant and isolates the
@@ -159,10 +159,10 @@ export function MethodologySection() {
             selected-year H5 rows are preserved separately in the production results.
           </p>
           <p className="mt-4">
-            <strong>Supplemental labor-supply response:</strong> will be republished
-            only from current-contract full reform H5 artifacts. Earlier non-contract
-            response data are excluded from the dashboard because they were not generated
-            from the current full-H5 production lineage.
+            <strong>Supplemental labor-supply response:</strong> uses the same
+            current-contract full reform H5 lineage and is available from the Scoring
+            control. Earlier non-contract response data are excluded from the dashboard
+            because they were not generated from the current full-H5 production lineage.
           </p>
         </AccordionItem>
 
@@ -171,8 +171,8 @@ export function MethodologySection() {
           summary="Revenue allocation varies by reform type."
         >
           <BulletList>
-            <li><strong>Options 1-2 and 8-10</strong>: current-law style benefit-tax allocation.</li>
-            <li><strong>Options 3-4 and 11</strong>: baseline-share allocation.</li>
+            <li><strong>Options 1-2 and 8-10</strong>: default to baseline-share allocation, with toggles for current-law, all-OASDI, and all-HI allocation.</li>
+            <li><strong>Options 3-4 and 11</strong>: use baseline-share allocation.</li>
             <li><strong>Options 5-6</strong>: employer-contribution taxes directed to their trust funds.</li>
             <li><strong>Option 7</strong>: total is the full federal income-tax gain; OASDI, HI, and general fund show the accounting split.</li>
             <li><strong>Option 12</strong>: handled through direct branching for the structural swap.</li>

--- a/dashboard/src/lib/reforms.ts
+++ b/dashboard/src/lib/reforms.ts
@@ -33,7 +33,7 @@ export const REFORMS: ReformMeta[] = [
     interpretation:
       "Negative values represent lost income-tax revenue currently credited to the OASDI and HI trust funds.",
     scoringNote:
-      "Static results are available for the full 2026-2100 window; current-contract labor-supply response results are pending.",
+      "Static and supplemental behavioral results are available for the full 2026-2100 window.",
   },
   {
     id: "option2",
@@ -49,7 +49,7 @@ export const REFORMS: ReformMeta[] = [
     interpretation:
       "Positive values show the added revenue from expanding the taxable-benefit base below the current thresholds.",
     scoringNote:
-      "Static results are available for the full 2026-2100 window; current-contract labor-supply response results are pending.",
+      "Static and supplemental behavioral results are available for the full 2026-2100 window.",
   },
   {
     id: "option3",
@@ -65,7 +65,7 @@ export const REFORMS: ReformMeta[] = [
     interpretation:
       "Results combine added taxable-benefit revenue with the offsetting cost of extending the senior deduction.",
     scoringNote:
-      "Static results are available for the full 2026-2100 window; current-contract labor-supply response results are pending.",
+      "Static and supplemental behavioral results are available for the full 2026-2100 window.",
   },
   {
     id: "option4",
@@ -81,7 +81,7 @@ export const REFORMS: ReformMeta[] = [
     interpretation:
       "The credit targets relief more directly than a deduction, so revenue effects reflect both the broader tax base and the capped credit offset.",
     scoringNote:
-      "Static results are available for the full 2026-2100 window; current-contract labor-supply response results are pending.",
+      "Static and supplemental behavioral results are available for the full 2026-2100 window.",
   },
   {
     id: "option5",
@@ -97,7 +97,7 @@ export const REFORMS: ReformMeta[] = [
     interpretation:
       "This is a structural tax-base shift from retirees toward workers, not just a change in taxable-benefit inclusion.",
     scoringNote:
-      "Static results are available; current-contract labor-supply response results are pending. trust-fund allocation follows the explicit OASDI/HI net-impact logic.",
+      "Static and supplemental behavioral results are available. Trust-fund allocation follows the explicit OASDI/HI net-impact logic.",
   },
   {
     id: "option6",
@@ -113,7 +113,7 @@ export const REFORMS: ReformMeta[] = [
     interpretation:
       "Use as a raw-data sensitivity rather than a primary publication-facing policy option.",
     scoringNote:
-      "Static results are available; current-contract labor-supply response results are pending. trust-fund allocation follows the explicit OASDI/HI net-impact logic.",
+      "Static and supplemental behavioral results are available. Trust-fund allocation follows the explicit OASDI/HI net-impact logic.",
   },
   {
     id: "option7",
@@ -128,7 +128,7 @@ export const REFORMS: ReformMeta[] = [
     interpretation:
       "Dashboard totals show the full federal income-tax gain; OASDI, HI, and general fund lines show where that gain is credited.",
     scoringNote:
-      "Static results are available; current-contract labor-supply response results are pending. TOB impacts are calculated from the saved marginal trust-fund revenue columns rather than from the full federal income-tax change.",
+      "Static and supplemental behavioral results are available. TOB impacts are calculated from the saved marginal trust-fund revenue columns rather than from the full federal income-tax change.",
   },
   {
     id: "option8",
@@ -144,7 +144,7 @@ export const REFORMS: ReformMeta[] = [
     interpretation:
       "This is the broadest direct benefit-taxation option, so positive revenue effects are larger than under 85, 90, or 95 percent inclusion.",
     scoringNote:
-      "Static results are available for the full 2026-2100 window; current-contract labor-supply response results are pending.",
+      "Static and supplemental behavioral results are available for the full 2026-2100 window.",
   },
   {
     id: "option9",
@@ -160,7 +160,7 @@ export const REFORMS: ReformMeta[] = [
     interpretation:
       "Revenue effects sit between uniform 85 percent taxation and broader 95 or 100 percent inclusion.",
     scoringNote:
-      "Static results are available for the full 2026-2100 window; current-contract labor-supply response results are pending.",
+      "Static and supplemental behavioral results are available for the full 2026-2100 window.",
   },
   {
     id: "option10",
@@ -176,7 +176,7 @@ export const REFORMS: ReformMeta[] = [
     interpretation:
       "Revenue effects are larger than under 85 or 90 percent inclusion but smaller than taxing all benefits.",
     scoringNote:
-      "Static results are available for the full 2026-2100 window; current-contract labor-supply response results are pending.",
+      "Static and supplemental behavioral results are available for the full 2026-2100 window.",
   },
   {
     id: "option11",
@@ -192,7 +192,7 @@ export const REFORMS: ReformMeta[] = [
     interpretation:
       "The larger credit provides more offset than the $500 design and phases out above higher incomes.",
     scoringNote:
-      "Static results are available for the full 2026-2100 window; current-contract labor-supply response results are pending.",
+      "Static and supplemental behavioral results are available for the full 2026-2100 window.",
   },
   {
     id: "option12",
@@ -208,7 +208,7 @@ export const REFORMS: ReformMeta[] = [
     interpretation:
       "The late-horizon sign can differ from the first decade because the payroll-tax inclusion and benefit-tax phaseout operate on different bases.",
     scoringNote:
-      "Static results are available; current-contract labor-supply response results are pending. trust-fund allocation follows the explicit OASDI/HI net-impact logic.",
+      "Static and supplemental behavioral results are available. Trust-fund allocation follows the explicit OASDI/HI net-impact logic.",
   },
 ];
 

--- a/docs/current/methodology.md
+++ b/docs/current/methodology.md
@@ -111,10 +111,10 @@ practice.
 
 Operationally:
 
-- the publication-facing dashboard defaults to static scoring and hides
-  labor-supply response estimates until they are generated from the current
-  full reform H5 contract
-- any future labor-supply response release must start from durable
+- the publication-facing dashboard defaults to static scoring and includes
+  supplemental behavioral rows only where generated from the current full
+  reform H5 contract
+- any labor-supply response release must start from durable
   `reform_full_h5/year=YYYY/reform=optionX/scenario.h5` artifacts; aggregate
   CSVs and non-contract sample panels are not production inputs
 

--- a/docs/current/pipeline.md
+++ b/docs/current/pipeline.md
@@ -54,7 +54,7 @@ delivered year.
 
 - [scripts/run_modal_refresh.py](../../scripts/run_modal_refresh.py)
   - snapshots calibrated H5 datasets, writes the reproducibility bundle, and
-    launches standard static or conventional reform panels on Modal
+    launches standard static or behavioral reform panels on Modal
 - [scripts/recover_modal_cells_run.py](../../scripts/recover_modal_cells_run.py)
   - recovers Modal cell-run outputs from the results volume and combines them
     into local CSV artifacts

--- a/paper/sections/03-methods.qmd
+++ b/paper/sections/03-methods.qmd
@@ -305,9 +305,11 @@ and HI.
 ## Supplemental labor-supply response scoring
 
 Static estimates are the primary scoring surface for the CRFB dashboard.
-Supplemental labor-supply response scoring is pending a current-contract full-H5
-rerun. Labor-supply response reform dictionaries merge the statutory reform
-parameters with the project's age-based elasticity schedule:
+Supplemental labor-supply response rows are included in the dashboard as a
+secondary scoring surface. They are generated from the same current-contract
+full-H5 reform lineage as the static rows, then aggregated from those durable
+H5 artifacts. Labor-supply response reform dictionaries merge the statutory
+reform parameters with the project's age-based elasticity schedule:
 
 - income elasticity base: `-0.05`
 - income elasticity multiplier above the model's older-worker threshold: `2.0`
@@ -323,11 +325,9 @@ response results therefore should be interpreted as partial-equilibrium revenue
 estimates under that specific elasticity schedule, not as macroeconomic
 forecasts. They are not official CBO or JCT scores.
 
-The public dashboard does not currently publish labor-supply response rows.
-Earlier response files were removed because they were not generated from the
-current full-H5 production lineage. New response rows must come from the same
-guarded full reform H5 contract as the static cells, then be aggregated from
-those durable H5 artifacts.
+The public dashboard labels these rows as behavioral. Earlier response files
+were removed because they were not generated from the current full-H5 production
+lineage; they are not part of the public release.
 
 ## Reproducibility and validation
 

--- a/paper/sections/05-results-framework.qmd
+++ b/paper/sections/05-results-framework.qmd
@@ -32,13 +32,13 @@ The publication rule is:
 
 {{< include exhibits/revenue-impacts.md >}}
 
-### Labor-supply response status
+### Supplemental labor-supply response
 
 {{< include exhibits/labor-supply-response-status.md >}}
 
-In the current release, the labor-supply response exhibit is a status note, not
-a results panel. Any response rows added later must be aggregated from saved
-full reform H5 artifacts produced under the current contract.
+In the current release, behavioral rows are supplemental to the static scoring
+surface. They are included only when generated from saved full reform H5
+artifacts produced under the current contract.
 
 ## Interpretation boundary
 

--- a/paper/sections/06-publication-boundary.qmd
+++ b/paper/sections/06-publication-boundary.qmd
@@ -61,15 +61,12 @@ That separation only works if each surface is honest about result status.
 - Operational notes should carry the detailed rerun state, launch identifiers,
   and recovery details needed to reconcile those two publication surfaces.
 
-For the current rebuild, that release discipline means the paper should not
-describe the dashboard package as final until the standard panel has been
-regenerated on the hardened exact-only path with the `2075+` donor-backed
-support supplement. The late-year support sentinels have cleared, but the
-publication result tables still need the sampled-year production run and reform
-rescoring pass before final language is appropriate.
+For the current rebuild, that release discipline means the dashboard-facing
+standard panel uses the hardened exact-only path, the `2075+` donor-backed
+support supplement, and saved full reform H5 artifacts before appearing in the
+public result surface.
 
 For the supplemental labor-supply response package, the standard `option1`
-through `option12` panel must be generated from durable full reform H5 artifacts
-under the current contract before it can be public. Multiplier-derived sample
-panels and other non-contract response artifacts are excluded from the release
-surface.
+through `option12` panel is public only where generated from durable full reform
+H5 artifacts under the current contract. Multiplier-derived sample panels and
+other non-contract response artifacts are excluded from the release surface.

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -573,7 +573,7 @@ def test_validation_exhibit_uses_current_full_h5_contract_not_old_sentinel_csvs(
     assert "Older non-contract artifacts are not" in exhibit
 
 
-def test_labor_supply_response_exhibit_is_status_only():
+def test_labor_supply_response_exhibit_uses_current_contract():
     exhibit = (
         REPO_ROOT / "paper" / "exhibits" / "labor-supply-response-status.md"
     ).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- update dashboard methodology and reform notes to reflect live behavioral rows
- update paper/current docs so labor-response output is described as current-contract supplemental output, not pending
- clarify that allocation defaults to baseline shares where the dashboard provides trust-fund split toggles

## Tests
- cd dashboard && bun run lint
- cd dashboard && bun run build
- uv run pytest tests/test_release_artifacts.py -q