### PR TITLE
Make CRFB long-run scripts repo-relative; document opaque fields

### DIFF
--- a/batch/run_option12_standalone.py
+++ b/batch/run_option12_standalone.py
@@ -13,9 +13,15 @@ app = modal.App("option12-standalone")
 
 results_volume = modal.Volume.from_name("crfb-results", create_if_missing=True)
 
-POLICYENGINE_US_PATH = os.environ.get(
-    "CRFB_POLICYENGINE_US_PATH", "/Users/pavelmakarchuk/policyengine-us"
-)
+# Mounted into the Modal image below; must point at a local policyengine-us
+# checkout. Required (no implicit default), per the repo convention in
+# src/runtime_config.py.
+POLICYENGINE_US_PATH = os.environ.get("CRFB_POLICYENGINE_US_PATH")
+if not POLICYENGINE_US_PATH:
+    raise SystemExit(
+        "CRFB_POLICYENGINE_US_PATH must be set to a local policyengine-us "
+        "checkout (e.g. ~/PolicyEngine/policyengine-us)."
+    )
 
 image = (
     modal.Image.debian_slim(python_version="3.11")

--- a/batch/run_option14_only.py
+++ b/batch/run_option14_only.py
@@ -14,9 +14,15 @@ app = modal.App("option14-only")
 
 results_volume = modal.Volume.from_name("crfb-results", create_if_missing=True)
 
-POLICYENGINE_US_PATH = os.environ.get(
-    "CRFB_POLICYENGINE_US_PATH", "/Users/pavelmakarchuk/policyengine-us"
-)
+# Mounted into the Modal image below; must point at a local policyengine-us
+# checkout. Required (no implicit default), per the repo convention in
+# src/runtime_config.py.
+POLICYENGINE_US_PATH = os.environ.get("CRFB_POLICYENGINE_US_PATH")
+if not POLICYENGINE_US_PATH:
+    raise SystemExit(
+        "CRFB_POLICYENGINE_US_PATH must be set to a local policyengine-us "
+        "checkout (e.g. ~/PolicyEngine/policyengine-us)."
+    )
 
 image = (
     modal.Image.debian_slim(python_version="3.11")

--- a/scripts/audit_late_horizon_discontinuities.py
+++ b/scripts/audit_late_horizon_discontinuities.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 
 
-REPO = Path("/Users/maxghenis/PolicyEngine/crfb-tob-impacts")
+REPO = Path(__file__).resolve().parents[1]
 RESULTS = REPO / "results"
 DASHBOARD_DATA = REPO / "dashboard" / "public" / "data"
 STATIC = RESULTS / "all_static_results_full_h5_selected_panel_display_20260522.csv"

--- a/scripts/build_live_modeling_dashboard_data.py
+++ b/scripts/build_live_modeling_dashboard_data.py
@@ -486,6 +486,14 @@ def build_live_reform_status(
                         "ready" if year in baseline_ready_years else "missing"
                     ),
                     "reform_h5_status": reform_h5_status,
+                    # The long-run reweighting only targets age structure, SS
+                    # beneficiary counts, payroll, and TOB aggregates; federal
+                    # income tax is never a calibration constraint. Its level
+                    # (and the implied tax-to-GDP ratio) is therefore an
+                    # unconstrained by-product of the weight solve and is not
+                    # reliable in the late-horizon tail, even when the targeted
+                    # aggregates match. Hence "...known_income_tax_tail_caveat"
+                    # rather than a clean reviewed status.
                     "aggregate_status": (
                         "reviewed_with_known_income_tax_tail_caveat"
                         if reform_h5_status in {"complete", "sentinel_complete"}

--- a/scripts/compare_longrun_support_methods.py
+++ b/scripts/compare_longrun_support_methods.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 import sys
@@ -35,13 +36,19 @@ from src.tax_assumption_loader import (  # noqa: E402
 )
 
 
-DEFAULT_SUPPORT_DATASET = (
-    "/Users/maxghenis/PolicyEngine/_local_runs/"
-    "crfb_py_bundle_2100_20260513/2100.h5"
+# These default to bundles produced by the local CRFB long-run pipeline, which
+# live outside the repo. Override the directory with CRFB_LOCAL_RUNS_DIR, or pass
+# explicit paths on the command line, to run on another machine.
+LOCAL_RUNS_DIR = Path(
+    os.environ.get(
+        "CRFB_LOCAL_RUNS_DIR", str(Path.home() / "PolicyEngine" / "_local_runs")
+    )
 )
-DEFAULT_NO_SUPPORT_DATASET = (
-    "/Users/maxghenis/PolicyEngine/_local_runs/"
-    "crfb_py_bundle_2100_no_support_20260513/2100.h5"
+DEFAULT_SUPPORT_DATASET = str(
+    LOCAL_RUNS_DIR / "crfb_py_bundle_2100_20260513" / "2100.h5"
+)
+DEFAULT_NO_SUPPORT_DATASET = str(
+    LOCAL_RUNS_DIR / "crfb_py_bundle_2100_no_support_20260513" / "2100.h5"
 )
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "tmp" / "longrun_support_validation"
 

--- a/scripts/generate_paper_static_exhibits.py
+++ b/scripts/generate_paper_static_exhibits.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 
 
-REPO = Path("/Users/maxghenis/PolicyEngine/crfb-tob-impacts")
+REPO = Path(__file__).resolve().parents[1]
 RESULTS = REPO / "results"
 EXHIBITS = REPO / "paper" / "exhibits"
 SECTION_EXHIBITS = REPO / "paper" / "sections" / "exhibits"

--- a/scripts/publish_crfb_longrun_hf.py
+++ b/scripts/publish_crfb_longrun_hf.py
@@ -16,11 +16,19 @@ REQUIRE_DEFAULT_DATASET = (
 STAGING_PREFIX = f"staging/{VERSION}"
 REPO_ID = os.environ.get("CRFB_LONGRUN_HF_REPO_ID", "policyengine/policyengine-us-data")
 REPO_TYPE = "model"
+# Defaults to the long_term storage of a local crfb-pinned us-data checkout.
+# Override with CRFB_LONGRUN_LOCAL_DIR to publish from another location.
 LOCAL_LONG_TERM_DIR = Path(
     os.environ.get(
         "CRFB_LONGRUN_LOCAL_DIR",
-        "/Users/maxghenis/PolicyEngine/policyengine-us-data-crfb-pin/"
-        "policyengine_us_data/storage/long_term",
+        str(
+            Path.home()
+            / "PolicyEngine"
+            / "policyengine-us-data-crfb-pin"
+            / "policyengine_us_data"
+            / "storage"
+            / "long_term"
+        ),
     )
 )
 LOCAL_RELEASE_DIR = Path(

--- a/src/dashboard_baseline_assumptions.py
+++ b/src/dashboard_baseline_assumptions.py
@@ -464,6 +464,10 @@ def build_baseline_aggregates(tax_assumption_name: str) -> pd.DataFrame:
         [["year", *baseline_cols]]
         .rename(
             columns={
+                # baseline_revenue and federal_income_tax are the same quantity
+                # — the post-calibration microsimulation federal income tax
+                # aggregate. The dashboard column is just relabeled here; no
+                # rescaling or post-hoc adjustment is applied.
                 "baseline_revenue": "federal_income_tax",
                 "baseline_tob_oasdi": "release_tob_oasdi",
                 "baseline_tob_medicare_hi": "release_tob_hi",


### PR DESCRIPTION
## Summary

Legibility/portability cleanup of the CRFB scripts — removing hardcoded absolute paths so they run on any checkout, and documenting two fields that read opaquely. No behavior change on the happy path.

### 1. Remove hardcoded absolute paths

These scripts only ran on one machine because defaults were hardcoded absolute paths. They now resolve repo-relative or from `Path.home()`, with env-var overrides; the Modal batch scripts now require their env var (matching the repo's own convention) instead of defaulting to a foreign home.

| File | Before | After |
| --- | --- | --- |
| `scripts/audit_late_horizon_discontinuities.py` | `REPO = Path("/Users/maxghenis/PolicyEngine/crfb-tob-impacts")` | `REPO = Path(__file__).resolve().parents[1]` |
| `scripts/generate_paper_static_exhibits.py` | same hardcoded `REPO` | same repo-relative fix |
| `scripts/compare_longrun_support_methods.py` | two `/Users/maxghenis/PolicyEngine/_local_runs/...` dataset defaults | built from `CRFB_LOCAL_RUNS_DIR` (default `~/PolicyEngine/_local_runs`) |
| `scripts/publish_crfb_longrun_hf.py` | `/Users/maxghenis/.../policyengine-us-data-crfb-pin/...` default | built from `Path.home()` (env `CRFB_LONGRUN_LOCAL_DIR` already existed) |
| `batch/run_option12_standalone.py`, `batch/run_option14_only.py` | default mount path `/Users/pavelmakarchuk/policyengine-us` (exists on no other machine) | require `CRFB_POLICYENGINE_US_PATH`, raise a clear error if unset — matches `src/runtime_config.py` / `resolve_local_env_path` |

### 2. Document fields that read opaquely

- `scripts/build_live_modeling_dashboard_data.py`: comment on why `aggregate_status` carries `"reviewed_with_known_income_tax_tail_caveat"` — the long-run reweighting only targets age structure, SS beneficiary counts, payroll, and TOB aggregates; **federal income tax is never a calibration constraint**, so its level (and the implied tax-to-GDP ratio) is an unconstrained by-product of the weight solve and is unreliable in the late-horizon tail even when the targeted aggregates match.
- `src/dashboard_baseline_assumptions.py`: comment clarifying that `baseline_revenue` and `federal_income_tax` are the **same quantity** (the post-calibration microsimulation federal income tax aggregate) — the `.rename()` is a dashboard relabel, not a rescaling or post-hoc adjustment.

## Scope notes

- Left untouched: `results/**.json` and `dashboard/public/data/*_metadata.json` contain absolute paths, but those are **generated provenance artifacts** recording where files were at generation time — not runtime defaults. Rewriting them would falsify provenance.
- Pre-existing unrelated lint nits in the two `batch/` files (unused import, empty f-strings) are intentionally left out of scope.

## Testing

- `python -m py_compile` passes on all eight touched files.
- `ruff check` passes on the six long-run scripts; the two `batch/` files have only pre-existing (unrelated) ruff findings on lines this PR does not touch.
- CI `tests/test_dashboard_baseline_assumptions.py` imports `build_calibration_targets`; the only edit to that module is comment-only and lives in an unrelated `.rename()`, so behavior is unchanged. The `batch/` scripts are Modal entrypoints not exercised by the test suite.

Opening as **draft** for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
